### PR TITLE
Fix object origin offset for odd-dimension models & add Center Origin option

### DIFF
--- a/blender_magicavoxel.py
+++ b/blender_magicavoxel.py
@@ -1675,6 +1675,13 @@ class ImportVOX(bpy.types.Operator, ImportHelper):
         default=False,
     )
 
+    center_origin: BoolProperty(
+        name="Center Origin",
+        description="Place the object origin at the exact center of the mesh. "
+                    "Without this, models with odd dimensions have their origin offset by half a voxel",
+        default=False,
+    )
+
     def create_materials_vertex_colors(self, collection_name: str, _: VoxModel):
         vertex_color_mat = bpy.data.materials.new(name=collection_name + " Material")
         vertex_color_mat.use_nodes = True
@@ -1788,6 +1795,7 @@ class ImportVOX(bpy.types.Operator, ImportHelper):
                 "join_models",
                 "max_texture_size",
                 "import_material_props",
+                "center_origin",
             ),
         )
 
@@ -1879,9 +1887,9 @@ class ImportVOX(bpy.types.Operator, ImportHelper):
                         while voxel_iterator.move_next():
                             (x, y, z, value) = voxel_iterator.current
                             target_position = world_matrix @ mathutils.Vector((
-                                x + 0.5 - math.floor(mesh.grid.width * 0.5),
-                                y + 0.5 - math.floor(mesh.grid.depth * 0.5),
-                                z + 0.5 - math.floor(mesh.grid.height * 0.5)
+                                x + 0.5 - (mesh.grid.width * 0.5 if self.center_origin else math.floor(mesh.grid.width * 0.5)),
+                                y + 0.5 - (mesh.grid.depth * 0.5 if self.center_origin else math.floor(mesh.grid.depth * 0.5)),
+                                z + 0.5 - (mesh.grid.height * 0.5 if self.center_origin else math.floor(mesh.grid.height * 0.5))
                             ))
                             combined_mesh.voxels.add(int(target_position[0] - 0.5), int(target_position[1] - 0.5),
                                                      int(target_position[2] - 0.5), value)
@@ -2300,6 +2308,12 @@ class ImportVOX(bpy.types.Operator, ImportHelper):
     def get_vertex_pos(self, p: Tuple[float, float, float], grid: VoxelGrid) -> Tuple[float, float, float]:
         if self.join_models:
             return p[0] * self.voxel_size, p[1] * self.voxel_size, p[2] * self.voxel_size
+        if self.center_origin:
+            return (
+                (p[0] - grid.width * 0.5) * self.voxel_size,
+                (p[1] - grid.depth * 0.5) * self.voxel_size,
+                (p[2] - grid.height * 0.5) * self.voxel_size
+            )
         return (
             (p[0] - math.floor(grid.width * 0.5)) * self.voxel_size,
             (p[1] - math.floor(grid.depth * 0.5)) * self.voxel_size,
@@ -2609,6 +2623,7 @@ class VOX_PT_import_geometry(bpy.types.Panel):
         layout.prop(operator, "join_models")
 
         layout.prop(operator, "voxel_size")
+        layout.prop(operator, "center_origin")
         layout.row().prop(operator, "meshing_type")
         if operator.meshing_type in ["CUBES_AS_OBJ", "SIMPLE_CUBES"]:
             layout.row().prop(operator, "voxel_hull")


### PR DESCRIPTION
## Fix object origin offset for odd-dimension models & add Center Origin option

### Problem

When importing MagicaVoxel models with odd dimensions (e.g. 3×3×3), the object origin is offset by half a voxel (`0.5 * voxel_size`) from the geometric center of the mesh. This happens because `math.floor()` is used to compute the centering offset — for odd values like 3, `math.floor(3 * 0.5)` yields `1` instead of the true center `1.5`.

This causes issues when positioning, rotating, or snapping objects in Blender, as the origin doesn't sit at the expected center.

### Fix

This PR adds a **Center Origin** import option (checkbox in the Geometry panel) that uses exact floating-point division (`grid.width * 0.5`) instead of `math.floor(grid.width * 0.5)`, placing the origin at the precise geometric center for all dimensions.

The option defaults to **off** to preserve backward compatibility with the existing behavior.

**Changes:**
- `get_vertex_pos()`: adds a branch that uses exact `* 0.5` centering when the option is enabled
- Join-models path: same conditional for the world-space transform offset
- New `BoolProperty` `center_origin` on the `ImportVOX` operator
- UI: checkbox added to the `VOX_PT_import_geometry` panel

### Example

For a 3-wide model:

| | Old (`math.floor`) | New (Center Origin) |
|---|---|---|
| Offset | `floor(1.5) = 1` | `1.5` |
| Origin error | `0.5 * voxel_size` | `0` |

---

First of all, thank you for this amazing addon — it's by far the best MagicaVoxel importer for Blender and I really appreciate the work you've put into it! I hope this small contribution is useful.