### PR TITLE
fix: add socket identifier fallback for shader node input/output key …

### DIFF
--- a/blender_magicavoxel.py
+++ b/blender_magicavoxel.py
@@ -1397,6 +1397,10 @@ class ShaderNodeProxy:
             return translated_key
         if key in node.inputs:
             return key
+        # Fallback: match by socket identifier (stable across locales and versions)
+        for inp in node.inputs:
+            if inp.identifier == key:
+                return inp.name
         if alternatives is not None:
             for alternative in alternatives:
                 translated_key = bpy.app.translations.pgettext(alternative)
@@ -1404,6 +1408,9 @@ class ShaderNodeProxy:
                     return translated_key
                 if alternative in node.inputs:
                     return alternative
+                for inp in node.inputs:
+                    if inp.identifier == alternative:
+                        return inp.name
         print("[WARN] Failed to find shader node input key '%s' or any alternative %s" % (key, alternatives))
         return None
 
@@ -1414,6 +1421,10 @@ class ShaderNodeProxy:
             return translated_key
         if key in node.outputs:
             return key
+        # Fallback: match by socket identifier (stable across locales and versions)
+        for out in node.outputs:
+            if out.identifier == key:
+                return out.name
         if alternatives is not None:
             for alternative in alternatives:
                 translated_key = bpy.app.translations.pgettext(alternative)
@@ -1421,6 +1432,9 @@ class ShaderNodeProxy:
                     return translated_key
                 if alternative in node.outputs:
                     return alternative
+                for out in node.outputs:
+                    if out.identifier == alternative:
+                        return out.name
         print("[WARN] Failed to find shader node output key '%s' or any alternative %s" % (key, alternatives))
         return None
 


### PR DESCRIPTION
## Fix shader node socket lookup for localized Blender installations

### Problem

When Blender is running in a non-English locale (e.g. German, French, Japanese), shader node socket names are translated. The importer already attempts to handle this via `bpy.app.translations.pgettext()`, but this fails when:

- The translation table is incomplete or outdated
- Socket display names change between Blender versions
- A locale uses unexpected translations for standard socket names like "Base Color", "Roughness", etc.

When the lookup fails, the addon prints a warning and returns `None`, which causes material setup to break silently — resulting in missing links in the shader graph and incorrect material appearance.

### Fix

Add a **socket identifier fallback** to both `get_node_input_key()` and `get_node_output_key()` in `ShaderNodeProxy`. The `identifier` property of a Blender socket is always the original English name and remains stable across locales and Blender versions.

The lookup order is now:
1. Translated name via `pgettext(key)`
2. Original English `key`
3. **New: Match by `socket.identifier == key`** → return `socket.name`
4. Same three steps for each alternative key

This ensures the correct socket is found regardless of Blender's UI language, without breaking any existing behavior for English installations.

### Changes

- `ShaderNodeProxy.get_node_input_key()`: added identifier fallback for primary key and alternatives
- `ShaderNodeProxy.get_node_output_key()`: same identifier fallback

---

Thank you for this great addon — it's hands down the best MagicaVoxel importer for Blender! This small fix should help users running Blender in non-English locales.